### PR TITLE
Fix approved hash slot computation

### DIFF
--- a/src/abis/events.ts
+++ b/src/abis/events.ts
@@ -5,7 +5,7 @@ export const SAFE_PROXY_CREATION = keccak256(
   toBytes('ProxyCreation(address,address)')
 )
 
-export const APPROVE_HASH = keccak256(toBytes('ApproveHash(address,address)'))
+export const APPROVE_HASH = keccak256(toBytes('ApproveHash(bytes32,address)'))
 export const SIGN_MSG = keccak256(toBytes('SignMsg(bytes32)'))
 
 export function decodeSafeProxyCreation(log: Log) {

--- a/src/storageSlot.ts
+++ b/src/storageSlot.ts
@@ -66,7 +66,7 @@ export const slotSignedMessage = (msgHash: Hex) => {
 export const slotApprovedHash = (owner: Hex, msgHash: Hex) => {
   // approvedHashes -> mapping(address => mapping(bytes32 => uint256)) internal approvedHashes;
   const SLOT_8 =
-    '0x0000000000000000000000000000000000000000000000000000000000000007'
+    '0x0000000000000000000000000000000000000000000000000000000000000008'
   owner = encodeAbiParameters([{ type: 'address' }], [owner])
 
   return keccak256(concat([msgHash, keccak256(concat([owner, SLOT_8]))]))


### PR DESCRIPTION
The script didn't work for safes that had approved hashes due to two reasons:
1. The event wasn't correctly decoded due to mismatched types
2. The mapping's slot number was incorrect